### PR TITLE
Improve script exit codes

### DIFF
--- a/libscanbuild/__init__.py
+++ b/libscanbuild/__init__.py
@@ -119,6 +119,8 @@ def command_entry_point(function):
             else:
                 logging.error("Please run this command again and turn on "
                               "verbose mode (add '-vvvv' as argument).")
+        except SystemExit as syserr:
+            exit_code = syserr.code
         finally:
             logging.shutdown()
             return exit_code

--- a/libscanbuild/intercept.py
+++ b/libscanbuild/intercept.py
@@ -57,10 +57,6 @@ def intercept_build_main(bin_dir):
     reconfigure_logging(args.verbose)
     logging.debug('Parsed arguments: %s', args)
 
-    if not args.build:
-        parser.print_help()
-        return 0
-
     return capture(args, bin_dir)
 
 

--- a/tests/functional/cases/test_create_cdb.py
+++ b/tests/functional/cases/test_create_cdb.py
@@ -93,6 +93,10 @@ class ExitCodeTest(unittest.TestCase):
             exitcode = self.run_intercept(tmpdir, 'build_broken')
             self.assertTrue(exitcode)
 
+    def test_intercept_help(self):
+        exitcode = silent_call(['intercept-build', '--help'])
+        self.assertFalse(exitcode)
+
 
 class ResumeFeatureTest(unittest.TestCase):
     @staticmethod


### PR DESCRIPTION
If the scripts --help command was called the default 127 exit code was returned even if the call was successful. Setting the default exit code to 0 resolves this issue.