### PR TITLE
Gitignore file for python source code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+__pycache__/
+*.py[cod]
+*$py.class
+
+*.so
+
+# Distribution / packaging
+.Python
+build/
+dist/
+eggs/
+.eggs/
+lib/
+lib64/
+sdist/
+*.egg-info/
+*.egg


### PR DESCRIPTION
This gitignore file can be useful to prevent accidentally adding compiled files or built python packages to the git commits.