### PR TITLE
intercept-build to work with response files.

### DIFF
--- a/libscanbuild/compilation.py
+++ b/libscanbuild/compilation.py
@@ -49,7 +49,13 @@ IGNORED_FLAGS = {
     '-u': 1,
     '-z': 1,
     '-T': 1,
-    '-Xlinker': 1
+    '-Xlinker': 1,
+    # clang-cl / msvc cl specific flags
+    # consider moving visual studio specific warning flags also
+    '-nologo': 0,
+    '-EHsc': 0,
+    '-EHa': 0
+
 }  # type: Dict[str, int]
 
 # Known C/C++ compiler wrapper name patterns


### PR DESCRIPTION
More info: https://msdn.microsoft.com/en-us/library/3te4xt0y.aspx

QT's qmake nmake generator generates makefile that puts all the
compilation units into response file. Thus, when compiling with
intercept-build to generate compilation_database.json, it won't get
populated due to _split_command not being able to detect any source
files in the intercepted call.

This patch will read the response file and append its data as
commandline parameters.

Includes unittest - essentially it covers also the functionality
so i dont see any need for "proper" functional test.