### PR TITLE
Add a -q/--quiet flag

### DIFF
--- a/libscanbuild/__init__.py
+++ b/libscanbuild/__init__.py
@@ -90,7 +90,10 @@ def reconfigure_logging(verbose_level):
 
     root = logging.getLogger()
     # tune level
-    level = logging.WARNING - min(logging.WARNING, (10 * verbose_level))
+    if verbose_level == -1:
+        level = logging.ERROR
+    else:
+        level = logging.WARNING - min(logging.WARNING, (10 * verbose_level))
     root.setLevel(level)
     # be verbose with messages
     if verbose_level <= 3:

--- a/libscanbuild/arguments.py
+++ b/libscanbuild/arguments.py
@@ -28,6 +28,15 @@ __all__ = ['parse_args_for_intercept_build', 'parse_args_for_analyze_build',
            'parse_args_for_scan_build']
 
 
+def get_verbosity(args):
+    """The number of -v flags, or -1 if -q was used."""
+    verbosity = args.verbose
+    if verbosity == 0 and args.quiet:
+        # -q should only be considered if -v was not used
+        verbosity = -1
+    return verbosity
+
+
 def parse_args_for_intercept_build():
     # type: () -> argparse.Namespace
     """ Parse and validate command-line arguments for intercept-build. """
@@ -35,7 +44,7 @@ def parse_args_for_intercept_build():
     parser = create_intercept_parser()
     args = parser.parse_args()
 
-    reconfigure_logging(args.verbose)
+    reconfigure_logging(get_verbosity(args))
     logging.debug('Raw arguments %s', sys.argv)
 
     # short validation logic
@@ -54,7 +63,7 @@ def parse_args_for_analyze_build():
     parser = create_analyze_parser(from_build_command)
     args = parser.parse_args()
 
-    reconfigure_logging(args.verbose)
+    reconfigure_logging(get_verbosity(args))
     logging.debug('Raw arguments %s', sys.argv)
 
     normalize_args_for_analyze(args, from_build_command)
@@ -71,7 +80,7 @@ def parse_args_for_scan_build():
     parser = create_analyze_parser(from_build_command)
     args = parser.parse_args()
 
-    reconfigure_logging(args.verbose)
+    reconfigure_logging(get_verbosity(args))
     logging.debug('Raw arguments %s', sys.argv)
 
     normalize_args_for_analyze(args, from_build_command)
@@ -368,6 +377,11 @@ def create_default_parser():
         default=0,
         help="""Enable verbose output from '%(prog)s'. A second, third and
         fourth flags increases verbosity.""")
+    parser.add_argument(
+        '--quiet',
+        '-q',
+        action='store_true',
+        help="Be less verbose (only show error output).")
     return parser
 
 


### PR DESCRIPTION
I find the default warning message about empty reports to be annoying. This adds a -q/--quiet flag that will suppress the warning log level.

I'm not 100% this is correct because with this change `wrapper_environment()` still creates `ENVIRONMENT_KEY` with a `"verbose"` key that does not consider the value of `args.quiet`. I'm open to handling this another way too, the way the argument handling and log setting works seemed kind of weird to me.