### PR TITLE
Add support for static analysis of cross compilation

### DIFF
--- a/libscanbuild/analyze.py
+++ b/libscanbuild/analyze.py
@@ -164,6 +164,7 @@ def analyze_parameters(args):
         'output_format': args.output_format,
         'output_failures': args.output_failures,
         'direct_args': direct_args(args),
+        'analyzer_target': args.analyzer_target,
         'force_debug': args.force_debug,
         'excludes': args.excludes
     }
@@ -486,6 +487,20 @@ def arch_check(opts, continuation=language_check):
     return continuation(opts)
 
 
+@require(['analyzer_target', 'flags'])
+def target_check(opts, continuation=arch_check):
+    # type: (...) -> Dict[str, Any]
+    """ Do run analyzer through the given target triple """
+
+    target = opts.pop("analyzer_target")
+    if target is not None:
+        opts.update({'flags': ['-target', target] + opts['flags']})
+        logging.debug("analysis, target triple is %s", target)
+    else:
+        logging.debug("analysis, default target triple")
+    return continuation(opts)
+
+
 # To have good results from static analyzer certain compiler options shall be
 # omitted. The compiler flag filtering only affects the static analyzer run.
 #
@@ -513,7 +528,7 @@ IGNORED_FLAGS = {
 
 
 @require(['flags'])
-def classify_parameters(opts, continuation=arch_check):
+def classify_parameters(opts, continuation=target_check):
     # type: (...) -> Dict[str, Any]
     """ Prepare compiler flags (filters some and add others) and take out
     language (-x) and architecture (-arch) flags for future processing. """

--- a/libscanbuild/arguments.py
+++ b/libscanbuild/arguments.py
@@ -248,6 +248,13 @@ def create_analyze_parser(from_build_command):
         static analysis. One can override this behavior with this option by
         using the 'clang' packaged with Xcode (on OS X) or from the PATH.""")
     advanced.add_argument(
+        '--analyzer-target',
+        dest='analyzer_target',
+        metavar='<target triple name for analysis>',
+        help="""This provides target triple information to clang static analyzer.
+        It only changes the target for analysis but doesn't change the target
+        of a real compiler given by --use-cc and --use-c++ options.""")
+    advanced.add_argument(
         '--no-failure-reports',
         '-no-failure-reports',
         dest='output_failures',
@@ -404,7 +411,12 @@ def parser_add_compilers(parser):
         your default compiler.
 
         If you need '%(prog)s' to use a specific compiler for *compilation*
-        then you can use this option to specify a path to that compiler.""")
+        then you can use this option to specify a path to that compiler.
+
+        If the given compiler is a cross compiler, you may also need to provide
+        --analyzer-target option to properly analyze the source code because
+        static analyzer runs as if the code is compiled for the host machine by
+        default.""")
     parser.add_argument(
         '--use-c++',
         metavar='<path>',


### PR DESCRIPTION
This adds the `-analyzer-target` option to specify target triple, which may be
necessary when `--use-cc` or `--use-c++` are cross compilers.