### PR TITLE
allow configuring cc/cxx on analyze

### DIFF
--- a/libscanbuild/analyze.py
+++ b/libscanbuild/analyze.py
@@ -43,7 +43,6 @@ COMPILER_WRAPPER_CC = 'analyze-cc'
 COMPILER_WRAPPER_CXX = 'analyze-c++'
 ENVIRONMENT_KEY = 'ANALYZE_BUILD'
 
-
 @command_entry_point
 def scan_build():
     # type: () -> int
@@ -81,7 +80,7 @@ def analyze_build():
     # will re-assign the report directory as new output
     with report_directory(args.output, args.keep_empty) as args.output:
         # run the analyzer against a compilation db
-        compilations = CompilationDatabase.load(args.cdb)
+        compilations = CompilationDatabase.load(args.cdb, cc=args.cc, cxx=args.cxx)
         run_analyzer_parallel(compilations, args)
         # cover report generation and bug counting
         number_of_bugs = document(args)
@@ -304,7 +303,6 @@ def run(opts):
     that the needed parameters received. (This is done by the 'require'
     decorator. It's like an 'assert' to check the contract between the
     caller and the called method.) """
-
     command = [opts['compiler'], '-c'] + opts['flags'] + [opts['source']]
     logging.debug("Run analyzer against '%s'", command)
     return exclude(opts)

--- a/libscanbuild/arguments.py
+++ b/libscanbuild/arguments.py
@@ -160,10 +160,10 @@ def create_analyze_parser(from_build_command):
     """ Creates a parser for command-line arguments to 'analyze'. """
 
     parser = create_default_parser()
+    parser_add_compilers(parser)
 
     if from_build_command:
         parser_add_prefer_wrapper(parser)
-        parser_add_compilers(parser)
 
         parser.add_argument(
             '--intercept-first',

--- a/libscanbuild/compilation.py
+++ b/libscanbuild/compilation.py
@@ -136,7 +136,7 @@ class Compilation:
         }
 
     @classmethod
-    def from_db_entry(cls, entry):
+    def from_db_entry(cls, entry, cc, cxx):
         # type: (Type[Compilation], Dict[str, str]) -> Iterable[Compilation]
         """ Parser method for compilation entry.
 
@@ -148,7 +148,7 @@ class Compilation:
         command = shell_split(entry['command']) if 'command' in entry else \
             entry['arguments']
         execution = Execution(cmd=command, cwd=entry['directory'], pid=0)
-        return cls.iter_from_execution(execution)
+        return cls.iter_from_execution(execution, cc=cc, cxx=cxx)
 
     @classmethod
     def iter_from_execution(cls,        # type: Type[Compilation]
@@ -293,7 +293,7 @@ class CompilationDatabase:
             json.dump(entries, handle, sort_keys=True, indent=4)
 
     @staticmethod
-    def load(filename):
+    def load(filename, cc='cc', cxx='c++'):
         # type: (str) -> Iterable[Compilation]
         """ Load compilations from file.
 
@@ -302,7 +302,7 @@ class CompilationDatabase:
 
         with open(filename, 'r') as handle:
             for entry in json.load(handle):
-                for compilation in Compilation.from_db_entry(entry):
+                for compilation in Compilation.from_db_entry(entry, cc=cc, cxx=cxx):
                     yield compilation
 
 


### PR DESCRIPTION
When trying to use a compilation database generated from a bazel build, I found that analyze-build was finishing suspiciously quickly, and reporting no issues. After tracing this locally, I found that the code was trying to find 'cc' or 'c++' in the command for each entry. However, the command in the case of bazel is `external/local_config_cc/wrapped_clang`. I noticed that these strings are configurable via command line arguments when the `cdb` flag is not being used, so I changed the argument parser to always include those flags. Not sure this is the right solution. If it is, I'd like to follow up with some tests.