### PR TITLE
Handle os.path.commonprefix exceptions

### DIFF
--- a/libscanbuild/report.py
+++ b/libscanbuild/report.py
@@ -492,8 +492,13 @@ def safe_readlines(filename):
 def chop(prefix, filename):
     # type: (str, str) -> str
     """ Create 'filename' from '/prefix/filename' """
-
-    return filename if not prefix else os.path.relpath(filename, prefix)
+    result = filename
+    if prefix:
+        try:
+            result = os.path.relpath(filename, prefix)
+        except ValueError:
+            pass
+    return result
 
 
 def escape(text):

--- a/libscanbuild/report.py
+++ b/libscanbuild/report.py
@@ -548,15 +548,12 @@ def commonprefix(files):
     :param files: list of file names.
     :return: the longest path prefix that is a prefix of all files. """
     result = None
-    try:
-        for current in files:
-            if result is not None:
-                result = os.path.commonprefix([result, current])
-            else:
-                result = current
-    except ValueError:
-        result = None
-                
+    for current in files:
+        if result is not None:
+            result = os.path.commonprefix([result, current])
+        else:
+            result = current
+
     if result is None:
         return ''
     elif not os.path.isdir(result):

--- a/libscanbuild/report.py
+++ b/libscanbuild/report.py
@@ -548,12 +548,15 @@ def commonprefix(files):
     :param files: list of file names.
     :return: the longest path prefix that is a prefix of all files. """
     result = None
-    for current in files:
-        if result is not None:
-            result = os.path.commonprefix([result, current])
-        else:
-            result = current
-
+    try:
+        for current in files:
+            if result is not None:
+                result = os.path.commonprefix([result, current])
+            else:
+                result = current
+    except ValueError:
+        result = None
+                
     if result is None:
         return ''
     elif not os.path.isdir(result):

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -116,6 +116,8 @@ class ReportMethodTest(unittest.TestCase):
         self.assertEqual('lib\\file',
                          sut.chop('c:\\prefix\\', 'c:\\prefix\\lib\\file'))
         self.assertEqual('c:\\prefix\\file', sut.chop('', 'c:\\prefix\\file'))
+        self.assertEqual('c:\\prefix\\file',
+                         sut.chop('e:\\prefix', 'c:\\prefix\\file'))
 
     @unittest.skipIf(not IS_WINDOWS, 'windows has different path patterns')
     def test_chop_when_cwd_on_windows(self):


### PR DESCRIPTION

On Windows, when using different drives between source and report, commonprefix raises an exception "ValueError("path is on mount %r, start on mount %r" % (path_drive, start_drive))"
(see https://github.com/python/cpython/blob/master/Lib/ntpath.py#L703)

Fixes #123 