### PR TITLE
Allow specifying compiler for buiding libear

### DIFF
--- a/libscanbuild/arguments.py
+++ b/libscanbuild/arguments.py
@@ -426,6 +426,13 @@ def parser_add_compilers(parser):
         dest='cxx',
         default=os.getenv('CXX', 'c++'),
         help="""This is the same as "--use-cc" but for C++ code.""")
+    parser.add_argument(
+        '--intercept-lib-cc',
+        metavar="<path>",
+        dest='libear_cc',
+        help="""The compiler for building interception library, defaulted to
+        the value of "--use-cc"."""
+    )
 
 
 class AppendCommaSeparated(argparse.Action):

--- a/libscanbuild/intercept.py
+++ b/libscanbuild/intercept.py
@@ -125,7 +125,8 @@ def setup_environment(args, destination):
             'CXX': COMPILER_WRAPPER_CXX,
         })
     else:
-        intercept_library = build_libear(args.cc, destination)
+        libear_cc = args.libear_cc if 'libear_cc' in args else args.cc
+        intercept_library = build_libear(libear_cc, destination)
         if sys.platform == 'darwin':
             environment.update({
                 'DYLD_INSERT_LIBRARIES': intercept_library,


### PR DESCRIPTION
In intercept mode, libear is currently built using compiler specifed by `--use-cc`. If that compiler is a cross-compiler then it may not able to build libear, or the result libbear is not able to intercept build commands because it doesn't target the build machine.

This change adds `--intercept-lib-cc` options to allow user to specify correct compiler to build libear. To maintain backward compatibility, its default value is value of `--use-cc`.